### PR TITLE
BUG: Module not added to package; not importable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@ import os
 from setuptools import find_packages, setup
 
 
+def read(fname):
+    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
+        return f.read()
+
+
 setup(
     name='ranger',
     version='0.0.1',
@@ -13,6 +18,8 @@ setup(
     package_dir={'ranger': os.path.join('.', 'ranger')},
     description='Ranger - a synergistic optimizer using RAdam '
                 '(Rectified Adam) and LookAhead in one codebase ',
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     author='Less Wright',
     license='Apache',
     install_requires=['torch']

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
-from setuptools import setup
+#!/usr/bin/env python
+
+import os
+from setuptools import find_packages, setup
+
 
 setup(
     name='ranger',
     version='0.0.1',
+    packages=find_packages(
+        exclude=['tests', '*.tests', '*.tests.*', 'tests.*']
+    ),
+    package_dir={'ranger': os.path.join('.', 'ranger')},
     description='Ranger - a synergistic optimizer using RAdam '
                 '(Rectified Adam) and LookAhead in one codebase ',
     author='Less Wright',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='ranger',
-    version='0.0.1',
+    version='0.1.dev0',
     packages=find_packages(
         exclude=['tests', '*.tests', '*.tests.*', 'tests.*']
     ),


### PR DESCRIPTION
ranger currently cannot be used from a pip install because the ranger module was not added to the package. The package is entirely empty, resulting in the following error:
```
$ pip install git+https://github.com/lessw2020/Ranger-Deep-Learning-Optimizer.git@73811db2eb55e1e3e3b736177cafaebe4807d669
[...]
Installing collected packages: ranger
Successfully installed ranger-0.0.1
$ python
>>> import ranger
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'ranger'
>>> from ranger import Ranger
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'ranger'
>>> import ranger.ranger
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'ranger'
```

This is resolved by using `setuptools.findpackages` to add the ranger module to the package.

I also added the README.md contents as long_description in setup.py, and incremented the version number to 0.1.dev0. Using dev or dev0 as the patch number indicates that the version is unstable, i.e. there is a one-to-many mapping from the version number, 0.1.dev0, to the state of the codebase in the repository.

I can split this out into multiple PRs if you'd prefer.