### PR TITLE
BUG: Fix setstate in RangerVA

### DIFF
--- a/ranger/ranger913A.py
+++ b/ranger/ranger913A.py
@@ -76,7 +76,7 @@ class RangerVA(Optimizer):
 
     def __setstate__(self, state):
         print("set state called")
-        super(Ranger, self).__setstate__(state)
+        super(RangerVA, self).__setstate__(state)
 
 
     def step(self, closure=None):


### PR DESCRIPTION
Fix reference to super class which was breaking `RangerVA.__setstate__(state)` and hence resuming from checkpoint with, for instance, `optimizer.load_state_dict(checkpoint["optimizer"])`.